### PR TITLE
Fix missing outboundCons from flux endpoint

### DIFF
--- a/src/services/fluxService.js
+++ b/src/services/fluxService.js
@@ -145,6 +145,7 @@ const dummyData = {
       dosMessage: null,
     },
     numberOfConnectionsIn: 0,
+    numberOfConnectionsOut: 0,
   },
   apps: {
     fluxusage: '0',
@@ -181,7 +182,6 @@ const dummyData = {
   collateralHash: '',
   collateralIndex: 0,
   roundTime: 0,
-  connectionsOut: 0,
   dataCollectedAt: 0,
 };
 async function getFluxNodeList(i = 0) {
@@ -512,26 +512,17 @@ async function processFluxNode(fluxnode, currentRoundTime, timeout, retry = fals
       fluxInfo.scannedHeight = scannedHeightInfo.generalScannedHeight;
       delete fluxInfo.flux.explorerScannedHeigth;
     }
-    let conOut = fluxInfo.flux.connectionsOut;
-    if (conOut) {
-      conOut = conOut.length;
-    } else if (fluxInfo.flux.numberOfConnectionsOut) {
-      conOut = fluxInfo.flux.numberOfConnectionsOut;
-      delete fluxInfo.flux.numberOfConnectionsOut;
-    } else {
+
+    if (typeof fluxInfo.flux.numberOfConnectionsOut !== "number") {
       const connectionsOut = await getConnectionsOut(fluxnode.ip, timeout);
-      conOut = connectionsOut.length;
+      fluxInfo.flux.numberOfConnectionsOut = connectionsOut.length;
     }
-    let conIn = fluxInfo.flux.connectionsIn;
-    if (conIn) {
-      conIn = conIn.length;
-    } else if (fluxInfo.flux.numberOfConnectionsIn) {
-      conIn = fluxInfo.flux.numberOfConnectionsOut;
-      delete fluxInfo.flux.numberOfConnectionsOut;
-    } else {
+
+    if (typeof fluxInfo.flux.numberOfConnectionsIn !== "number") {
       const connectionsIn = await getConnectionsIn(fluxnode.ip, timeout);
-      conIn = connectionsIn.length;
+      fluxInfo.flux.numberOfConnectionsIn = connectionsIn.length;
     }
+
     const auxIp = fluxnode.ip.split(':')[0];
 
     if (!myGeolocationCache.has(auxIp)) {
@@ -574,14 +565,6 @@ async function processFluxNode(fluxnode, currentRoundTime, timeout, retry = fals
     fluxInfo.collateralHash = getCollateralInfo(fluxnode.collateral).txhash;
     fluxInfo.collateralIndex = getCollateralInfo(fluxnode.collateral).txindex;
     fluxInfo.roundTime = currentRoundTime;
-
-    if (conOut) {
-      fluxInfo.connectionsOut = conOut;
-    }
-
-    if (conIn) {
-      fluxInfo.connectionsIn = conIn;
-    }
 
     const curTime = new Date().getTime();
     fluxInfo.dataCollectedAt = curTime;


### PR DESCRIPTION
Not sure of the workflow for fluxstats, so just merging to master. Please correct me if wrong.

There are a couple of things going on here, I'm not sure of the history here, I'm guessing we used to display the actual connection info on the `flux/info` api endpoint, but it got removed in favor or the connection count?

There was a copy / paste typo on the `else if (fluxInfo.flux.numberOfConnectionsIn)` stanza where it was referencing `numberOfConnectionsOut`

This led to the `numberOfConnectionsIn` still being referenced under the flux endpoint, instead of the root endpoint. However, I don't understand why we are pulling the number of connections out of the Flux endpoint, as they are specific to fluxOS - not the whole node.

Since we no longer have `ConnectionsIn/Out` I have removed this extra logic. Again, if I'm missing something here, please correct me.

To summarize:

Connection count in / out should be under Flux, not the root.
Fix typo / logic to get correct connection count.

I'm unsure how testing is done on this repo - I've only done local testing on the function itself, which worked fine, but don't know how this will affect the rest of the code.